### PR TITLE
Fix header guards

### DIFF
--- a/src/Activations.h
+++ b/src/Activations.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef Activations_
-#define Activations_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -27,4 +26,3 @@ public:
 Activation* get_activation(const string & sActivation);
 void list_activations_available(vector<string>& vsActivations);
 
-#endif

--- a/src/CIFAR10Reader.h
+++ b/src/CIFAR10Reader.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef CIFAR10Reader_
-#define CIFAR10Reader_
+#pragma once
 
 #include "Matrix.h"
 
@@ -25,5 +24,3 @@ private:
     bool read_from_folder(const string& sFolder,MatrixFloat& mRefImages,MatrixFloat& mRefLabels,MatrixFloat& mTestImages,MatrixFloat& mTestLabels);
     bool read_batch(string sName,MatrixFloat& mData,MatrixFloat& mTruth);
 };
-
-#endif

--- a/src/CsvFileReader.h
+++ b/src/CsvFileReader.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef CsvFileReader_
-#define CsvFileReader_
+#pragma once
 
 #include <string>
 using namespace std;
@@ -21,5 +20,3 @@ public:
 private:
 	void replace_last(string& s, const string& sOld, const string& sNew);
 };
-
-#endif

--- a/src/DataSource.h
+++ b/src/DataSource.h
@@ -1,5 +1,4 @@
-#ifndef DataSource_
-#define DataSource_
+#pragma once
 
 #include <string>
 using namespace std;
@@ -37,4 +36,3 @@ protected:
 	bool _bHasValidationData;
 };
 
-#endif

--- a/src/Initializers.h
+++ b/src/Initializers.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef Initializers_
-#define Initializers_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -32,5 +31,3 @@ public:
 
     static void compute(const string& sInitializer, MatrixFloat& m, Index iInputSize, Index iOutputSize);
 };
-
-#endif

--- a/src/JsonFile.h
+++ b/src/JsonFile.h
@@ -6,9 +6,6 @@
     in the LICENSE.txt file.
 */
 
-#ifndef JsonFile_
-#define JsonFile_
-
 #include <string>
 using namespace std;
 
@@ -38,4 +35,3 @@ private:
     string _sOut;
 };
 
-#endif

--- a/src/KMeans.h
+++ b/src/KMeans.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef KMeans_
-#define KMeans_
+#pragma once
 
 #include "Matrix.h"
 
@@ -38,5 +37,3 @@ private:
 	int _iNbRef;
 	int _iInputSize;
 };
-
-#endif

--- a/src/KMeansTrain.h
+++ b/src/KMeansTrain.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef KMeansTrain_
-#define KMeansTrain_
+#pragma once
 
 #include "Matrix.h"
 
@@ -67,5 +66,3 @@ private:
 	float _fTrainAccuracy;
 	float _fValidationAccuracy;
 };
-
-#endif

--- a/src/Layer.h
+++ b/src/Layer.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef Layer_
-#define Layer_
+#pragma once
 
 #include "Matrix.h"
 
@@ -56,5 +55,3 @@ private:
     string _sType;
     string _sWeightInitializer, _sBiasInitializer;
 };
-
-#endif

--- a/src/LayerActivation.h
+++ b/src/LayerActivation.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerActivation_
-#define LayerActivation_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -33,4 +32,3 @@ private:
     Activation * _pActivation;
 };
 
-#endif

--- a/src/LayerAffine.h
+++ b/src/LayerAffine.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerAffine_
-#define LayerAffine_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -26,4 +25,3 @@ public:
     virtual void backpropagation(const MatrixFloat &mIn,const MatrixFloat &mGradientOut, MatrixFloat &mGradientIn) override;
 };
 
-#endif

--- a/src/LayerAveragePooling2D.h
+++ b/src/LayerAveragePooling2D.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerAveragePooling2D_
-#define LayerAveragePooling2D_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -39,5 +38,3 @@ private:
 
 	float _fInvKernelSize;
 };
-
-#endif

--- a/src/LayerBias.h
+++ b/src/LayerBias.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerBias_
-#define LayerBias_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -24,5 +23,3 @@ public:
     virtual void forward(const MatrixFloat& mIn, MatrixFloat &mOut) override;
     virtual void backpropagation(const MatrixFloat &mIn,const MatrixFloat &mGradientOut, MatrixFloat &mGradientIn) override;
 };
-
-#endif

--- a/src/LayerBilinear.h
+++ b/src/LayerBilinear.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerBilinear_
-#define LayerBilinear_
+#pragma once
 
 #include "LayerGatedActivation.h"
 
@@ -17,4 +16,3 @@ public:
     explicit LayerBilinear();
 };
 
-#endif

--- a/src/LayerCRelu.h
+++ b/src/LayerCRelu.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerCRelu_
-#define LayerCRelu_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -29,4 +28,3 @@ public:
 	virtual void backpropagation(const MatrixFloat &mIn,const MatrixFloat &mGradientOut, MatrixFloat &mGradientIn) override;
 };
 
-#endif

--- a/src/LayerChannelBias.h
+++ b/src/LayerChannelBias.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerChannelBias_
-#define LayerChannelBias_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -28,5 +27,3 @@ public:
 private:
 	Index _iNbRows,_iNbCols,_iNbChannels;
 };
-
-#endif

--- a/src/LayerConvolution2D.h
+++ b/src/LayerConvolution2D.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerConvolution2D_
-#define LayerConvolution2D_
+#pragma once
 
 #include <vector>
 using namespace std;
@@ -66,5 +65,3 @@ public:
 	MatrixFloat _im2colT; // input image, im2col format
 	MatrixFloat _tempImg; // temporary image, to avoid malloc
 };
-
-#endif

--- a/src/LayerDense.h
+++ b/src/LayerDense.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerDense_
-#define LayerDense_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -32,4 +31,3 @@ private:
 	Index _iInputSize, _iOutputSize;
 };
 
-#endif

--- a/src/LayerDot.h
+++ b/src/LayerDot.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerDot_
-#define LayerDot_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -32,4 +31,3 @@ private:
 	Index _iInputSize, _iOutputSize;
 };
 
-#endif

--- a/src/LayerDropout.h
+++ b/src/LayerDropout.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerDropout_
-#define LayerDropout_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -30,4 +29,3 @@ private:
 	MatrixFloat _mask;
 };
 
-#endif

--- a/src/LayerFactory.h
+++ b/src/LayerFactory.h
@@ -1,5 +1,4 @@
-#ifndef LayerFactory_
-#define LayerFactory_
+#pragma once
 
 #include <string>
 using namespace std;
@@ -12,4 +11,4 @@ public:
     static Layer* create(const string& sLayer ,float fArg1=0.f,float fArg2=0.f,float fArg3=0.f,float fArg4=0.f,float fArg5=0.f);	
 };
 
-#endif
+

--- a/src/LayerGEGLU.h
+++ b/src/LayerGEGLU.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerGEGLU_
-#define LayerGEGLU_
+#pragma once
 
 #include "LayerGatedActivation.h"
 
@@ -16,4 +15,3 @@ class LayerGEGLU : public LayerGatedActivation
 public:
     explicit LayerGEGLU();
 };
-#endif

--- a/src/LayerGLU.h
+++ b/src/LayerGLU.h
@@ -6,8 +6,7 @@
 	in the LICENSE.txt file.
 */
 
-#ifndef LayerGLU_
-#define LayerGLU_
+#pragma once
 
 #include "LayerGatedActivation.h"
 
@@ -17,4 +16,3 @@ public:
 	explicit LayerGLU();
 };
 
-#endif

--- a/src/LayerGTU.h
+++ b/src/LayerGTU.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerGTU_
-#define LayerGTU_
+#pragma once
 
 #include "LayerGatedActivation.h"
 
@@ -17,5 +16,4 @@ public:
     explicit LayerGTU();
 };
 
-#endif
 

--- a/src/LayerGain.h
+++ b/src/LayerGain.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerGain_
-#define LayerGain_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -25,5 +24,3 @@ public:
 	virtual void forward(const MatrixFloat& mIn, MatrixFloat &mOut) override;
 	virtual void backpropagation(const MatrixFloat &mIn,const MatrixFloat &mGradientOut, MatrixFloat &mGradientIn) override;
 };
-
-#endif

--- a/src/LayerGatedActivation.h
+++ b/src/LayerGatedActivation.h
@@ -6,8 +6,7 @@
 	in the LICENSE.txt file.
 */
 
-#ifndef LayerGatedActivation_
-#define LayerGatedActivation_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -31,5 +30,3 @@ private:
 	Activation* _pActivation1;
 	Activation* _pActivation2;
 };
-
-#endif

--- a/src/LayerGaussianDropout.h
+++ b/src/LayerGaussianDropout.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerGaussianDropout_
-#define LayerGaussianDropout_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -38,4 +37,3 @@ private:
 	normal_distribution<float> _distNormal;
 };
 
-#endif

--- a/src/LayerGaussianNoise.h
+++ b/src/LayerGaussianNoise.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerGaussianNoise_
-#define LayerGaussianNoise_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -32,5 +31,3 @@ private:
     float _fNoise;
 	normal_distribution<float> _distNormal;
 };
-
-#endif

--- a/src/LayerGlobalAffine.h
+++ b/src/LayerGlobalAffine.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerGlobalAffine_
-#define LayerGlobalAffine_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -26,4 +25,3 @@ public:
     virtual void backpropagation(const MatrixFloat &mIn,const MatrixFloat &mGradientOut, MatrixFloat &mGradientIn) override;
 };
 
-#endif

--- a/src/LayerGlobalAveragePooling2D.h
+++ b/src/LayerGlobalAveragePooling2D.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerGlobalAveragePooling2D_
-#define LayerGlobalAveragePooling2D_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -34,4 +33,3 @@ private:
 	float _fInvKernelSize;
 };
 
-#endif

--- a/src/LayerGlobalBias.h
+++ b/src/LayerGlobalBias.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerGlobalBias_
-#define LayerGlobalBias_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -25,4 +24,3 @@ public:
     virtual void backpropagation(const MatrixFloat &mIn,const MatrixFloat &mGradientOut, MatrixFloat &mGradientIn) override;
 };
 
-#endif

--- a/src/LayerGlobalGain.h
+++ b/src/LayerGlobalGain.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerGlobalGain_
-#define LayerGlobalGain_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -25,5 +24,3 @@ public:
     virtual void forward(const MatrixFloat& mIn, MatrixFloat &mOut) override;
     virtual void backpropagation(const MatrixFloat &mIn,const MatrixFloat &mGradientOut, MatrixFloat &mGradientIn) override;
 };
-
-#endif

--- a/src/LayerGlobalMaxPool2D.h
+++ b/src/LayerGlobalMaxPool2D.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerGlobalMaxPool2D_
-#define LayerGlobalMaxPool2D_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -35,4 +34,3 @@ private:
 	MatrixFloat _mMaxIndex;
 };
 
-#endif

--- a/src/LayerMaxPool2D.h
+++ b/src/LayerMaxPool2D.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerMaxPool2D_
-#define LayerMaxPool2D_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -40,4 +39,3 @@ private:
 	MatrixFloat _mMaxIndex;
 };
 
-#endif

--- a/src/LayerPELU.h
+++ b/src/LayerPELU.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerPELU_
-#define LayerPELU_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -26,4 +25,4 @@ public:
 	virtual void backpropagation(const MatrixFloat &mIn,const MatrixFloat &mGradientOut, MatrixFloat &mGradientIn) override;
 };
 
-#endif
+

--- a/src/LayerPRelu.h
+++ b/src/LayerPRelu.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerPRelu_
-#define LayerPRelu_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -26,4 +25,3 @@ public:
 	virtual void backpropagation(const MatrixFloat &mIn,const MatrixFloat &mGradientOut, MatrixFloat &mGradientIn) override;
 };
 
-#endif

--- a/src/LayerRNN.h
+++ b/src/LayerRNN.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerRNN_
-#define LayerRNN_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -37,4 +36,3 @@ protected:
     int _iUnits;
 };
 
-#endif

--- a/src/LayerRRelu.h
+++ b/src/LayerRRelu.h
@@ -5,9 +5,7 @@
     Use of this source code is governed by a MIT-style license that can be found
     in the LICENSE.txt file.
 */
-
-#ifndef LayerRRelu_
-#define LayerRRelu_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -35,5 +33,3 @@ private:
 	float _invAlpha2;
 	float _invAlphaMean;	
 };
-
-#endif

--- a/src/LayerRandomFlip.h
+++ b/src/LayerRandomFlip.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerRandomFlip_
-#define LayerRandomFlip_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -33,4 +32,3 @@ private:
     MatrixFloat _flipped;
 };
 
-#endif

--- a/src/LayerReGLU.h
+++ b/src/LayerReGLU.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerReGLU_
-#define LayerReGLU_
+#pragma once
 
 #include "LayerGatedActivation.h"
 
@@ -16,5 +15,3 @@ class LayerReGLU : public LayerGatedActivation
 public:
     explicit LayerReGLU();
 };
-
-#endif

--- a/src/LayerSeGLU.h
+++ b/src/LayerSeGLU.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerSeGLU_
-#define LayerSeGLU_
+#pragma once
 
 #include "LayerGatedActivation.h"
 
@@ -16,4 +15,4 @@ class LayerSeGLU : public LayerGatedActivation
 public:
     explicit LayerSeGLU();
 };
-#endif
+

--- a/src/LayerSimpleRNN.h
+++ b/src/LayerSimpleRNN.h
@@ -5,9 +5,7 @@
     Use of this source code is governed by a MIT-style license that can be found
     in the LICENSE.txt file.
 */
-
-#ifndef LayerSimpleRNN_
-#define LayerSimpleRNN_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -31,4 +29,3 @@ private:
     MatrixFloat _whh, _wxh, _bh;
 };
 
-#endif

--- a/src/LayerSimplestRNN.h
+++ b/src/LayerSimplestRNN.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerSimplestRNN_
-#define LayerSimplestRNN_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -28,5 +27,3 @@ public:
 
     virtual void backpropagation_frame(const MatrixFloat& mInFrame, const MatrixFloat& mH, const MatrixFloat& mHm1, const MatrixFloat& mGradientOut, MatrixFloat& mGradientIn) override;
 };
-
-#endif

--- a/src/LayerSoftmax.h
+++ b/src/LayerSoftmax.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerSoftmax_
-#define LayerSoftmax_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -24,4 +23,3 @@ public:
     virtual void backpropagation(const MatrixFloat &mIn,const MatrixFloat &mGradientOut, MatrixFloat &mGradientIn) override;
 };
 
-#endif

--- a/src/LayerSoftmin.h
+++ b/src/LayerSoftmin.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerSoftmin_
-#define LayerSoftmin_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -23,5 +22,3 @@ public:
     virtual void forward(const MatrixFloat& mIn, MatrixFloat &mOut) override;
     virtual void backpropagation(const MatrixFloat &mIn,const MatrixFloat &mGradientOut, MatrixFloat &mGradientIn) override;
 };
-
-#endif

--- a/src/LayerSwiGLU.h
+++ b/src/LayerSwiGLU.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerSwiGLU_
-#define LayerSwiGLU_
+#pragma once
 
 #include "LayerGatedActivation.h"
 
@@ -16,4 +15,3 @@ class LayerSwiGLU : public LayerGatedActivation
 public:
     explicit LayerSwiGLU();
 };
-#endif

--- a/src/LayerTERELU.h
+++ b/src/LayerTERELU.h
@@ -6,9 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerTERELU_
-#define LayerTERELU_
-
+#pragma once
 #include "Layer.h"
 #include "Matrix.h"
 
@@ -28,5 +26,3 @@ public:
 private:
     float _alpha, _mu;
 };
-
-#endif

--- a/src/LayerTimeDistributedBias.h
+++ b/src/LayerTimeDistributedBias.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerTimeDistributedBias_
-#define LayerTimeDistributedBias_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -28,4 +27,3 @@ private:
 	int _iFrameSize;
 };
 
-#endif

--- a/src/LayerTimeDistributedDense.h
+++ b/src/LayerTimeDistributedDense.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerTimeDistributedDense_
-#define LayerTimeDistributedDense_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -29,5 +28,3 @@ public:
 private:
 	int _iInFrameSize, _iOutFrameSize;
 };
-
-#endif

--- a/src/LayerTimeDistributedDot.h
+++ b/src/LayerTimeDistributedDot.h
@@ -5,9 +5,7 @@
     Use of this source code is governed by a MIT-style license that can be found
     in the LICENSE.txt file.
 */
-
-#ifndef LayerTimeDistributedDot_
-#define LayerTimeDistributedDot_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -30,4 +28,3 @@ private:
 	int _iInFrameSize, _iOutFrameSize;
 };
 
-#endif

--- a/src/LayerUniformNoise.h
+++ b/src/LayerUniformNoise.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerUniformNoise_
-#define LayerUniformNoise_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -34,5 +33,3 @@ private:
 	uniform_real_distribution<float> _distUniform;
 
 };
-
-#endif

--- a/src/LayerZeroPadding2D.h
+++ b/src/LayerZeroPadding2D.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef LayerZeroPadding2D_
-#define LayerZeroPadding2D_
+#pragma once
 
 #include "Layer.h"
 #include "Matrix.h"
@@ -35,5 +34,3 @@ private:
 	Index _iInChannels;
 	Index _iBorder;
 };
-
-#endif

--- a/src/Loss.h
+++ b/src/Loss.h
@@ -5,9 +5,7 @@
     Use of this source code is governed by a MIT-style license that can be found
     in the LICENSE.txt file.
 */
-
-#ifndef Loss_
-#define Loss_
+#pragma once
 
 #include "Matrix.h"
 
@@ -40,5 +38,3 @@ protected:
 
 Loss* create_loss(const string & sLoss);
 void list_loss_available(vector<string>& vsLoss);
-
-#endif

--- a/src/MNISTReader.h
+++ b/src/MNISTReader.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef MNISTReader_
-#define MNISTReader_
+#pragma once
 
 #include "Matrix.h"
 #include "DataSource.h"
@@ -25,4 +24,3 @@ private:
 	void swap_int(unsigned int &i);
 };
 
-#endif

--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef Matrix_
-#define Matrix_
+#pragma once
 
 #include <algorithm>
 #include <cassert>
@@ -734,4 +733,3 @@ const MatrixFloat fromFile(const string& sFile);
 const MatrixFloat fromString(const string& s);
 bool toFile(const string& sFile, const MatrixFloat & m);
 
-#endif

--- a/src/MetaOptimizer.h
+++ b/src/MetaOptimizer.h
@@ -1,5 +1,4 @@
-#ifndef MetaOptimizer_
-#define MetaOptimizer_
+#pragma once
 
 #include "NetTrain.h"
 
@@ -77,5 +76,3 @@ private:
 	vector< OptimizerVariation > _optimizerVariations;
 
 };
-
-#endif

--- a/src/Metrics.h
+++ b/src/Metrics.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef Metrics_
-#define Metrics_
+#pragma once
 
 #include "Matrix.h"
 
@@ -30,5 +29,3 @@ private:
     MatrixFloat _mConfusionMatrix; //raw count
     MatrixFloat _mConfusionMatrixNormalized; //in %
 };
-
-#endif

--- a/src/MinMaxScaler.h
+++ b/src/MinMaxScaler.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef MinMaxScaler_
-#define MinMaxScaler_
+#pragma once
 
 #include "Matrix.h"
 
@@ -22,5 +21,3 @@ public:
 private:
 	MatrixFloat _mMin, _mMax;
 };
-
-#endif

--- a/src/Net.h
+++ b/src/Net.h
@@ -5,9 +5,7 @@
     Use of this source code is governed by a MIT-style license that can be found
     in the LICENSE.txt file.
 */
-
-#ifndef Net_
-#define Net_
+#pragma once
 
 #include <vector>
 using namespace std;
@@ -49,5 +47,3 @@ private:
 	vector<Layer*> _layers;
 	bool _bClassificationMode;
 };
-
-#endif

--- a/src/NetTrain.h
+++ b/src/NetTrain.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef NetTrain_
-#define NetTrain_
+#pragma once
 
 #include "Matrix.h"
 
@@ -153,4 +152,3 @@ private:
 	float _fValidationAccuracy;
 };
 
-#endif

--- a/src/NetUtil.h
+++ b/src/NetUtil.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef NetUtil_
-#define NetUtil_
+#pragma once
 
 class Net;
 class NetTrain;
@@ -25,4 +24,3 @@ namespace NetUtil {
     //string find_key(string s,string sKey);
     //void split(string s, vector<string>& vsItems, char cDelimiter=' ');
 }
-#endif

--- a/src/Optimizer.h
+++ b/src/Optimizer.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef Optimizer_
-#define Optimizer_
+#pragma once
 
 #include "Matrix.h"
 
@@ -43,5 +42,3 @@ protected:
 
 Optimizer* create_optimizer(const string & sOptimizer);
 void list_optimizers_available(vector<string>& vsOptimizers);
-
-#endif

--- a/src/Regularizer.h
+++ b/src/Regularizer.h
@@ -5,9 +5,7 @@
     Use of this source code is governed by a MIT-style license that can be found
     in the LICENSE.txt file.
 */
-
-#ifndef Regularizer_
-#define Regularizer_
+#pragma once
 
 #include "Matrix.h"
 
@@ -37,4 +35,3 @@ protected:
 Regularizer* create_regularizer(const string & sRegularizer);
 void list_regularizer_available(vector<string>& vsRegularizers);
 
-#endif

--- a/src/StandardScaler.h
+++ b/src/StandardScaler.h
@@ -6,8 +6,7 @@
     in the LICENSE.txt file.
 */
 
-#ifndef StandardScaler_
-#define StandardScaler_
+#pragma once
 
 #include "Matrix.h"
 
@@ -23,4 +22,3 @@ private:
 	MatrixFloat _mMean, _mStd;
 };
 
-#endif


### PR DESCRIPTION
Replaces header guards with `#pragma once` so that the symbols don't conflict with others found in this library or other libraries. Common symbol names like `Layer_` and `Metrics_` are likely conflict.